### PR TITLE
update for async v0.15

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,4 +3,4 @@
  (public_names wscat wstest)
  (preprocess (pps ppx_jane))
  (package fastws-async)
- (libraries core async fastws-async))
+ (libraries core core_unix.command_unix async fastws-async))

--- a/bin/wscat.ml
+++ b/bin/wscat.ml
@@ -1,4 +1,5 @@
 open Core
+open Core_unix
 open Async
 open Log.Global
 
@@ -26,4 +27,4 @@ let () =
     [%map_open
       let () = set_level_via_param () and url = anon ("url" %: url_cmd) in
       fun () -> Fastws_async_raw.to_or_error (main url)])
-  |> Command.run
+  |> Command_unix.run

--- a/bin/wstest.ml
+++ b/bin/wstest.ml
@@ -1,4 +1,5 @@
 open Core
+open Core_unix
 open Async
 open Fastws
 open Log.Global
@@ -23,8 +24,8 @@ let main url section tests =
 let url_cmd = Command.Arg_type.create Uri.of_string
 
 let pp_header ppf (l, _) =
-  let now = Time_ns.now () in
-  Format.fprintf ppf "%a [%a] " Time_ns.pp now Logs.pp_level l
+  let now = Time_ns_unix.now () in
+  Format.fprintf ppf "%a [%a] " Time_ns_unix.pp now Logs.pp_level l
 
 let range_of_string s =
   match String.rsplit2 s ~on:'-' with
@@ -47,4 +48,4 @@ let () =
       and section = anon ("section" %: string)
       and tests = anon ("tests" %: range) in
       fun () -> main url section tests])
-  |> Command.run
+  |> Command_unix.run

--- a/fastws-async.opam
+++ b/fastws-async.opam
@@ -12,11 +12,11 @@ depends: [
   "fastws"
   "base64" {>= "3.4.0"}
   "uri-sexp" {>= "4.0.0"}
-  "core" {>= "v0.14.0"}
-  "async" {>= "v0.14.0"}
+  "core" {>= "v0.15.0"}
+  "async" {>= "v0.15.0"}
   "logs-async" {>= "1.1"}
   "faraday-async" {>= "0.7.2"}
-  "async-uri" {>= "0.2.1"}
+  "async-uri" {>= "0.3.0"}
   "zlib" {>= "0.6"}
   "alcotest" {with-test & >= "1.2.3"}
   "alcotest-async" {with-test & >= "1.2.3"}

--- a/fastws.opam
+++ b/fastws.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.09.0"}
   "dune" {>= "1.11.4"}
   "sexplib" {>= "v0.14.0"}
-  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_sexp_conv" {>= "v0.15.1"}
   "faraday" {>= "0.7.2"}
   "httpaf" {>= "0.6.6"}
   "alcotest" {with-test & >= "1.2.3"}

--- a/src/fastws_async.ml
+++ b/src/fastws_async.ml
@@ -19,7 +19,7 @@ type st =
   { buf: Bigbuffer.t;
     mutable header: Header.t option;
     mutable conn_state: [`Open | `Closing | `Closed];
-    on_pong: Time_ns.Span.t option -> unit;
+    on_pong: Time_ns_unix.Span.t option -> unit;
     permessage_deflate: bool;
     inflate: Zlib.inflate Zlib.t }
 
@@ -138,10 +138,10 @@ let r3_of_r2 st ({Frame.header; payload} as frame) =
         Ok (None, None)
     | _ ->
         ( try
-            let now = Time_ns.now () in
-            let old = Time_ns.of_string (Bigstring.to_string payload) in
-            let diff = Time_ns.diff now old in
-            Log.debug (fun m -> m "<- PONG %a" Time_ns.Span.pp diff) ;
+            let now = Time_ns_unix.now () in
+            let old = Time_ns_unix.of_string (Bigstring.to_string payload) in
+            let diff = Time_ns_unix.diff now old in
+            Log.debug (fun m -> m "<- PONG %a" Time_ns_unix.Span.pp diff) ;
             st.on_pong (Some diff)
           with _ -> () ) ;
         Ok (None, None) )
@@ -154,9 +154,9 @@ let heartbeat w span =
   let write_ping () =
     Log_async.debug (fun m -> m "-> PING")
     >>= fun () ->
-    let ping = Frame.String.pingf "%a" Time_ns.pp (Time_ns.now ()) in
+    let ping = Frame.String.pingf "%a" Time_ns_unix.pp (Time_ns_unix.now ()) in
     Fastws_async_raw.write_frame_if_open w ping in
-  let start = Time_ns.(add (now ()) span) in
+  let start = Time_ns_unix.(add (now ()) span) in
   let stop = Pipe.closed w in
   Clock_ns.run_at_intervals' ~continue_on_error:false ~start ~stop span
     write_ping

--- a/src/fastws_async.mli
+++ b/src/fastws_async.mli
@@ -11,12 +11,12 @@ open Httpaf
 type ('r, 'w) t = {r: 'r Pipe.Reader.t; w: 'w Pipe.Writer.t}
 
 val connect :
-  ?on_pong:(Time_ns.Span.t option -> unit) ->
+  ?on_pong:(Time_ns_unix.Span.t option -> unit) ->
   ?extra_headers:Headers.t ->
   ?extensions:(string * string option) list ->
   ?protocols:string list ->
   ?monitor:Monitor.t ->
-  ?hb:Time_ns.Span.t ->
+  ?hb:Time_ns_unix.Span.t ->
   Uri.t ->
   Reader.t ->
   Writer.t ->
@@ -25,12 +25,12 @@ val connect :
   (('r, 'w) t, Fastws_async_raw.err) Deferred.Result.t
 
 val with_connection :
-  ?on_pong:(Time_ns.Span.t option -> unit) ->
+  ?on_pong:(Time_ns_unix.Span.t option -> unit) ->
   ?extra_headers:Headers.t ->
   ?extensions:(string * string option) list ->
   ?protocols:string list ->
   ?monitor:Monitor.t ->
-  ?hb:Time_ns.Span.t ->
+  ?hb:Time_ns_unix.Span.t ->
   Uri.t ->
   Reader.t ->
   Writer.t ->
@@ -43,24 +43,24 @@ val of_frame_s : Frame.t -> string
 val to_frame_s : string -> Frame.t
 
 val connect_or_result :
-  ?on_pong:(Time_ns.Span.t option -> unit) ->
+  ?on_pong:(Time_ns_unix.Span.t option -> unit) ->
   ?extra_headers:Headers.t ->
   ?extensions:(string * string option) list ->
   ?protocols:string list ->
   ?monitor:Monitor.t ->
-  ?hb:Time_ns.Span.t ->
+  ?hb:Time_ns_unix.Span.t ->
   (Frame.t -> 'r) ->
   ('w -> Frame.t) ->
   Uri.t ->
   (('r, 'w) t, Fastws_async_raw.err) Deferred.Result.t
 
 val connect_or_error :
-  ?on_pong:(Time_ns.Span.t option -> unit) ->
+  ?on_pong:(Time_ns_unix.Span.t option -> unit) ->
   ?extra_headers:Headers.t ->
   ?extensions:(string * string option) list ->
   ?protocols:string list ->
   ?monitor:Monitor.t ->
-  ?hb:Time_ns.Span.t ->
+  ?hb:Time_ns_unix.Span.t ->
   (Frame.t -> 'r) ->
   ('w -> Frame.t) ->
   Uri.t ->


### PR DESCRIPTION
Update for core and async v0.15

* Replace `Command.run` with `Command_unix.run`
* Replace all uses of `Time_ns` with `Time_ns_unix`

Version of `async-uri` should be adjusted.